### PR TITLE
Link anchors and other documentation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,7 +16,7 @@ Suggests: testthat, arrow, qs, knitr, rmarkdown
 Encoding: UTF-8
 URL: https://github.com/kylebaron/mrgsim.parallel
 BugReports: https://github.com/kylebaron/mrgsim.parallel/issues
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.2
 Roxygen: list(markdown = TRUE)
 VignetteBuilder: knitr
 Language: en-US

--- a/R/data_parallel.R
+++ b/R/data_parallel.R
@@ -23,7 +23,7 @@
 #' be (1) the simulated output (2) the model object.
 #' @param .dry If `TRUE` neither the simulation nor the post processing will
 #' be done.
-#' @param .seed Passed to [future_lapply()] as `future.seed`.
+#' @param .seed Passed to [future.apply::future_lapply()] as `future.seed`.
 #' @param .parallel if `FALSE`, the simulation will not be parallelized; this is
 #' intended for debugging and testing use only.
 #'

--- a/R/mrgsim-bg.R
+++ b/R/mrgsim-bg.R
@@ -76,7 +76,7 @@ bg_sim_env <- function() {
 #'   
 #' 
 #' @return 
-#' An `r_process` object; see [callr::r_bg()]. Call `process$get_resuilt()` to 
+#' An `r_process` object; see [callr::r_bg()]. Call `process$get_result()` to 
 #' get the actual result (see `details`). If a `.locker` path is supplied, 
 #' the simulated data is saved to disk and a list of file names is returned. 
 #' 

--- a/man/bg_mrgsim_d.Rd
+++ b/man/bg_mrgsim_d.Rd
@@ -55,7 +55,7 @@ simulation sequentially.}
 parallelization will be handled by the \code{future} package.}
 }
 \value{
-An \code{r_process} object; see \code{\link[callr:r_bg]{callr::r_bg()}}. Call \code{process$get_resuilt()} to
+An \code{r_process} object; see \code{\link[callr:r_bg]{callr::r_bg()}}. Call \code{process$get_result()} to
 get the actual result (see \code{details}). If a \code{.locker} path is supplied,
 the simulated data is saved to disk and a list of file names is returned.
 }

--- a/man/parallel_mrgsim_d.Rd
+++ b/man/parallel_mrgsim_d.Rd
@@ -64,7 +64,7 @@ be (1) the simulated output (2) the model object.}
 \item{.dry}{If \code{TRUE} neither the simulation nor the post processing will
 be done.}
 
-\item{.seed}{Passed to \code{\link[=future_lapply]{future_lapply()}} as \code{future.seed}.}
+\item{.seed}{Passed to \code{\link[future.apply:future_lapply]{future.apply::future_lapply()}} as \code{future.seed}.}
 
 \item{.parallel}{if \code{FALSE}, the simulation will not be parallelized; this is
 intended for debugging and testing use only.}

--- a/man/parallel_mrgsim_ei.Rd
+++ b/man/parallel_mrgsim_ei.Rd
@@ -70,7 +70,7 @@ be (1) the simulated output (2) the model object.}
 \item{.dry}{If \code{TRUE} neither the simulation nor the post processing will
 be done.}
 
-\item{.seed}{Passed to \code{\link[=future_lapply]{future_lapply()}} as \code{future.seed}.}
+\item{.seed}{Passed to \code{\link[future.apply:future_lapply]{future.apply::future_lapply()}} as \code{future.seed}.}
 
 \item{.parallel}{if \code{FALSE}, the simulation will not be parallelized; this is
 intended for debugging and testing use only.}

--- a/mrgsim.parallel.Rproj
+++ b/mrgsim.parallel.Rproj
@@ -1,4 +1,5 @@
 Version: 1.0
+ProjectId: 99ed7a30-8e96-4bd0-ae2d-d282489026ca
 
 RestoreWorkspace: Default
 SaveWorkspace: Default


### PR DESCRIPTION

```r
Version: 0.2.1
Check: Rd cross-references
Result: NOTE 
  Found the following Rd file(s) with Rd \link{} targets missing package
  anchors:
    parallel_mrgsim_d.Rd: mrgsim_d, future_lapply
    parallel_mrgsim_ei.Rd: mrgsim_d, future_lapply
  Please provide package anchors for all Rd \link{} targets not in the
  package itself and the base packages.
```