### PR TITLE
Release/0.3.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,9 @@ Package: mrgsim.parallel
 Type: Package
 Title: Simulate with 'mrgsolve' in Parallel
 Version: 0.3.0
-Author: Kyle Baron
+Authors@R: c(
+    person("Kyle", "Baron", "", "kylebtwin@imap.cc", c("aut", "cre"))
+    )
 Maintainer: Kyle Baron <kylebtwin@imap.cc>
 Description: Simulation from an 'mrgsolve' 
     <https://cran.r-project.org/package=mrgsolve> model using a parallel backend.  

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: mrgsim.parallel
 Type: Package
 Title: Simulate with 'mrgsolve' in Parallel
-Version: 0.2.0.9002
+Version: 0.3.0
 Author: Kyle Baron
 Maintainer: Kyle Baron <kylebtwin@imap.cc>
 Description: Simulation from an 'mrgsolve' 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,13 @@
 # mrgsim.parallel 0.3.0
 
+- Fix anchor links to functions in other packages (#25). 
+
+- Fixed bug in `tag` argument to `bg_mrgsim_d()`; simulations are now
+  properly stored in `.locker/.tag` (#23). 
+
+- Add support for saving background sims in parquet format (#22).
+
+- Add method to create a new stream from a data frame (#20).
 
 
 # mrgsim.parallel 0.2.0

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,6 @@
-# mrgsim.parallel (development version)
+# mrgsim.parallel 0.3.0
+
+
 
 # mrgsim.parallel 0.2.0
 

--- a/R/data_parallel.R
+++ b/R/data_parallel.R
@@ -17,7 +17,7 @@
 #' @param data Data set to simulate; see [mrgsolve::data_set()].
 #' @param nchunk Number of chunks in which to split the data set; chunking will 
 #' be based on the `ID` column, which is required in `data`.
-#' @param ... Passed to [mrgsim_d()].
+#' @param ... Passed to [mrgsolve::mrgsim_d()].
 #' @param .as_list If `TRUE` a list is return; otherwise (default) a data frame
 #' @param .p Post processing function executed on the worker; arguments should
 #' be (1) the simulated output (2) the model object.

--- a/man/parallel_mrgsim_d.Rd
+++ b/man/parallel_mrgsim_d.Rd
@@ -54,7 +54,7 @@ fu_mrgsim_d0(..., .dry = TRUE)
 \item{nchunk}{Number of chunks in which to split the data set; chunking will
 be based on the \code{ID} column, which is required in \code{data}.}
 
-\item{...}{Passed to \code{\link[=mrgsim_d]{mrgsim_d()}}.}
+\item{...}{Passed to \code{\link[mrgsolve:mrgsim_variants]{mrgsolve::mrgsim_d()}}.}
 
 \item{.as_list}{If \code{TRUE} a list is return; otherwise (default) a data frame}
 

--- a/man/parallel_mrgsim_ei.Rd
+++ b/man/parallel_mrgsim_ei.Rd
@@ -60,7 +60,7 @@ see \code{\link[mrgsolve:idata_set]{mrgsolve::idata_set()}}.}
 \item{nchunk}{Number of chunks in which to split the data set; chunking will
 be based on the \code{ID} column, which is required in \code{data}.}
 
-\item{...}{Passed to \code{\link[=mrgsim_d]{mrgsim_d()}}.}
+\item{...}{Passed to \code{\link[mrgsolve:mrgsim_variants]{mrgsolve::mrgsim_d()}}.}
 
 \item{.as_list}{If \code{TRUE} a list is return; otherwise (default) a data frame}
 

--- a/tests/testthat/test-bg.R
+++ b/tests/testthat/test-bg.R
@@ -12,6 +12,7 @@ data <- mrgsolve::expand.ev(
   addl = 6
 )
 data$dose <- data$amt
+clean <- function(x) gsub("[[:punct:]]", "-", x, perl = TRUE)
 
 test_that("bg simulation has same result as fg", { 
   bg <- bg_mrgsim_d(
@@ -147,7 +148,10 @@ test_that("bg locker, no tag", {
     .plan = "sequential"
   )
   files <- bg$get_result()
-  expect_equal(dirname(files[[1]]), file.path(tempdir(), "foo"))
+  expect_equal(
+    clean(dirname(files[[1]])), 
+    clean(file.path(tempdir(), "foo"))
+  )
   bg2 <- bg_mrgsim_d(
     mod, 
     data, 
@@ -176,7 +180,10 @@ test_that("bg locker and tag", {
     .plan = "sequential"
   )
   files <- bg$get_result()[[1]]
-  expect_equal(dirname(files), file.path(tempdir(), "foo"))
+  expect_equal(
+    clean(dirname(files[1])), 
+    clean(file.path(tempdir(), "foo"))
+  )
   bg <- bg_mrgsim_d(
     mod, 
     data, 
@@ -189,8 +196,10 @@ test_that("bg locker and tag", {
     .plan = "sequential"
   )
   files <- bg$get_result()
-  expect_equal(dirname(files[[1]]), file.path(tempdir(), "foo", "run2"))
-  
+  expect_equal(
+    clean(dirname(files[[1]])), 
+    clean(file.path(tempdir(), "foo", "run2"))
+  )  
   bg2 <- bg_mrgsim_d(
     mod, 
     data, 


### PR DESCRIPTION
# mrgsim.parallel 0.3.0

- Fix anchor links to functions in other packages (#25). 

- Fixed bug in `tag` argument to `bg_mrgsim_d()`; simulations are now
  properly stored in `.locker/.tag` (#23). 

- Add support for saving background sims in parquet format (#22).

- Add method to create a new stream from a data frame (#20).