### PR TITLE
bg_mrgsim_d_impl: drop unbalanced nocov comment

### DIFF
--- a/R/mrgsim-bg.R
+++ b/R/mrgsim-bg.R
@@ -220,7 +220,7 @@ bg_mrgsim_d_impl <- function(data, mod, output = NULL, .seed = NULL,
     )
     return(output)
   } 
-  if(.format == "parquet") { #nocov start
+  if(.format == "parquet") {
     arrow::write_parquet( 
       x = out,
       sink = output


### PR DESCRIPTION
ea6f8a6 (add parquet output format for bg_mrgsim, 2024-07-03) added a `#nocov start` without the closing `#nocov end`, which triggers a covr error:

    Error in parse_exclusions(x$file_lines, exclude_pattern, exclude_start,  :
      2 range starts but only 1 range end for exclusion from code coverage!
    Calls: package_coverage -> exclude -> lapply -> FUN -> parse_exclusions

The unbalanced `#nocov start` is already within another nocov block, so drop the comment rather than adding a closing comment.